### PR TITLE
Enable ScriptedPlugin explicitly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,9 @@
 // This build is for this Giter8 template.
 // To test the template run `g8` or `g8Test` from the sbt session.
 // See http://www.foundweekends.org/giter8/testing.html#Using+the+Giter8Plugin for more details.
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .enablePlugins(ScriptedPlugin)
+  .settings(
     name := "akka-http-scala-seed.g8",
     test in Test := {
       val _ = (g8Test in Test).toTask("").value


### PR DESCRIPTION
I noticed my previous PR, https://github.com/akka/akka-http-quickstart-scala.g8/pull/49, cause build failed. That is caused by updating sbt to 1.2.0. After sbt 1.2.0, we need to enable Scripted Plugin explicitly. 