### PR TITLE
Reflect asynchronous nature of bindAndHandle()

### DIFF
--- a/src/main/g8/src/main/scala/$package$/QuickstartServer.scala
+++ b/src/main/g8/src/main/scala/$package$/QuickstartServer.scala
@@ -1,8 +1,9 @@
 package $package$
 
 //#quick-start-server
-import scala.concurrent.Await
+import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.concurrent.duration.Duration
+import scala.util.{ Failure, Success }
 
 import akka.actor.{ ActorRef, ActorSystem }
 import akka.http.scaladsl.Http
@@ -17,6 +18,7 @@ object QuickstartServer extends App with UserRoutes {
   //#server-bootstrapping
   implicit val system: ActorSystem = ActorSystem("helloAkkaHttpServer")
   implicit val materializer: ActorMaterializer = ActorMaterializer()
+  implicit val executionContext: ExecutionContext = system.dispatcher
   //#server-bootstrapping
 
   val userRegistryActor: ActorRef = system.actorOf(UserRegistryActor.props, "userRegistryActor")
@@ -27,9 +29,16 @@ object QuickstartServer extends App with UserRoutes {
   //#main-class
 
   //#http-server
-  Http().bindAndHandle(routes, "localhost", 8080)
+  val serverBinding: Future[Http.ServerBinding] = Http().bindAndHandle(routes, "localhost", 8080)
 
-  println(s"Server online at http://localhost:8080/")
+  serverBinding.onComplete {
+    case Success(bound) =>
+      println(s"Server online at http://\${bound.localAddress.getHostString}:\${bound.localAddress.getPort}/")
+    case Failure(e) =>
+      Console.err.println(s"Server could not start!")
+      e.printStackTrace()
+      system.terminate()
+  }
 
   Await.result(system.whenTerminated, Duration.Inf)
   //#http-server


### PR DESCRIPTION
I noticed that the example does not wait for the success of the serverbinding, but boldly declares the server on-line right after starting the binding attempt. This PR remedies that.

Perhaps simplicity is preferred over accuracy here; in that case, please disregard this PR.