### PR TITLE
Review travisCI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 scala:
-  - 2.12.10
-  - 2.13.1
+  - 2.12.11
+  - 2.13.2
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,27 @@ scala:
   - 2.12.10
   - 2.13.1
 
-before_install:
-  - curl -sL https://raw.githubusercontent.com/shyiko/jabba/0.11.1/install.sh | bash && . ~/.jabba/jabba.sh
-  - jabba install adopt@~1.8.0-222
+env:
+  matrix:
+    - TRAVIS_JDK=adopt@1.8.0-242
+    - TRAVIS_JDK=adopt@1.11.0-6
+
+before_install: curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
+install: jabba install "$TRAVIS_JDK" && jabba use "$_" && java -Xmx32m -version
 
 # These directories are cached to S3 at the end of the build
 cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot/
+    - $HOME/.gradle
     - $HOME/.jabba/jdk
-    - $HOME/.cache/coursier
 
 script:
-  - jabba use ${JDK:=adopt@~1.8.0-222}
-  - java -version
   ## This runs the template with the default parameters, and runs test within the templated app.
   - sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M test docs/paradox
 
-  # Tricks to avoid unnecessary cache updates
-  - find $HOME/.sbt -name "*.lock" | xargs rm
-  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
+before_cache:
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt  -name "*.lock"               -print -delete
+


### PR DESCRIPTION
Brings the Travis CI setup close to other samples such as https://github.com/akka/akka-grpc-quickstart-scala.g8:

 - bump scala versions
 - use multiple scala versions
 - use multiple (and newer) JDKs
 - copy the jabba installer script from other repos.
