### PR TITLE
Replace deprecated class of scalatest with new one

### DIFF
--- a/src/main/g8/src/test/scala/$package$/UserRoutesSpec.scala
+++ b/src/main/g8/src/test/scala/$package$/UserRoutesSpec.scala
@@ -7,10 +7,11 @@ import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 //#set-up
-class UserRoutesSpec extends WordSpec with Matchers with ScalaFutures with ScalatestRouteTest {
+class UserRoutesSpec extends AnyWordSpec with Matchers with ScalaFutures with ScalatestRouteTest {
   //#test-top
 
   // the Akka HTTP route testkit does not yet support a typed actor system (https://github.com/akka/akka-http/issues/2036)


### PR DESCRIPTION
**org.scalatest.Matchers** and **org.scalatest.WordSpec** have already depracted since ScalaTest 3.1.x
Replace **with org.scalatest.matchers.should.Matchers** and **org.scalatest.wordspec.AnyWordSpec**