### PR TITLE
fix: drop revolver plugin

### DIFF
--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
+


### PR DESCRIPTION
No longer available from original coordinates (sbt repo shutdown), not sure why we should have it in the quickstarts to begin with so dropping instead of picking the new version/coordinates.
