### PR TITLE
bump: Default to Scala 3

### DIFF
--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,6 +1,6 @@
 name=My Akka HTTP Project
 description=This is a seed project which creates a basic build for an Akka HTTP application using Scala.
-scala_version=2.13.14
+scala_version=3.3.3
 akka_http_version=10.6.3
 akka_version=2.9.3
 sbt_version=maven(org.scala-sbt, sbt, stable)


### PR DESCRIPTION
But keep it cross-compilable with 2.13 so users can choose that if they want.