### PR TITLE
ci: bump ubuntu-20.04 to ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   build-test:
     if: github.repository == 'akka/akka-http-quickstart-scala.g8'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Got an email from GitHub:

> [Action Required] Ubuntu-20.04 hosted runner image is closing down
> 
> The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025